### PR TITLE
feat: speed up parsing advertisement data

### DIFF
--- a/src/bluetooth_data_tools/__init__.py
+++ b/src/bluetooth_data_tools/__init__.py
@@ -3,12 +3,7 @@ from __future__ import annotations
 
 from struct import Struct
 
-from .gap import (
-    BLEGAPAdvertisement,
-    BLEGAPType,
-    decode_advertisement_data,
-    parse_advertisement_data,
-)
+from .gap import BLEGAPAdvertisement, BLEGAPType, parse_advertisement_data
 from .utils import int_to_bluetooth_address
 
 __version__ = "0.4.0"
@@ -24,7 +19,6 @@ __all__ = [
     "short_address",
     "BLEGAPType",
     "BLEGAPAdvertisement",
-    "decode_advertisement_data",
     "parse_advertisement_data",
 ]
 

--- a/src/bluetooth_data_tools/gap.py
+++ b/src/bluetooth_data_tools/gap.py
@@ -78,9 +78,9 @@ _BLEGAPType_MAP = {gap_ad.value: gap_ad for gap_ad in BLEGAPType}
 _bytes = bytes
 
 
-def decode_advertisement_data(
+def _decode_advertisement_data(
     encoded_struct: _bytes,
-) -> Iterable[Tuple[BLEGAPType, bytes]]:
+) -> Iterable[Tuple[int, bytes]]:
     """Decode a BLE GAP AD structure."""
     offset = 0
     total_length = len(encoded_struct)
@@ -108,7 +108,7 @@ def decode_advertisement_data(
             )
             return
 
-        yield _BLEGAPType_MAP.get(type_, BLEGAPType.TYPE_UNKNOWN), value
+        yield type_, value
         offset += 1 + length
 
 
@@ -140,8 +140,7 @@ def parse_advertisement_data(
     tx_power: int | None = None
 
     for gap_data in data:
-        for gap_type, gap_value in decode_advertisement_data(gap_data):
-            gap_type_num = gap_type.value
+        for gap_type_num, gap_value in _decode_advertisement_data(gap_data):
             if gap_type_num == TYPE_SHORT_LOCAL_NAME and not local_name:
                 local_name = gap_value.decode("utf-8", errors="replace")
             elif gap_type_num == TYPE_COMPLETE_LOCAL_NAME:


### PR DESCRIPTION
BREAKING CHANGE: The `decode_advertisement_data` function is no longer exposed

It is likely nobody was using it since it is internals for `parse_advertisement_data`, but it was exposed. If this is a problem for you, please open an issue.