### PR TITLE
feat: optimize gap parser

### DIFF
--- a/src/bluetooth_data_tools/gap.pxd
+++ b/src/bluetooth_data_tools/gap.pxd
@@ -27,7 +27,13 @@ cdef cython.uint TYPE_TX_POWER_LEVEL
 
 
 @cython.locals(
+    gap_data=cython.bytes,
     gap_value=cython.bytes,
-    gap_type_num=cython.uint
+    gap_type_num=cython.uint,
+    total_length=cython.uint,
+    length=cython.uint,
+    offset=cython.uint,
+    start=cython.uint,
+    end=cython.uint,
 )
 cpdef parse_advertisement_data(object data)


### PR DESCRIPTION
before
Parsing 100000 bluetooth messages took 3.1390244999784045 seconds

after
Parsing 100000 bluetooth messages took 1.6808899159659632 seconds
