### PR TITLE
build: remove wheel from list of build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,5 +94,5 @@ module = "docs.*"
 ignore_errors = true
 
 [build-system]
-requires = ['setuptools>=65.4.1', 'wheel', 'Cython', "poetry-core>=1.0.0"]
+requires = ['setuptools>=65.4.1', 'Cython', "poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
It doesn't look like this is used.

A separate question: is the Cython version intended to be the preferred one (or only one) moving forward? I'm doing some work on this package in [nixpkgs](https://github.com/NixOS/nixpkgs) and wondering which one to build. Since it is listed as a build dependency in pyproject.toml, does it mean it's preferred?