### PR TITLE
feat: increase parser cache size

### DIFF
--- a/src/bluetooth_data_tools/gap.py
+++ b/src/bluetooth_data_tools/gap.py
@@ -147,7 +147,7 @@ def _manufacturer_id_bytes_to_int(manufacturer_id_bytes: bytes_) -> int:
 _cached_manufacturer_id_bytes_to_int = _manufacturer_id_bytes_to_int
 
 
-@lru_cache(maxsize=256)
+@lru_cache(maxsize=512)
 def _parse_advertisement_data(
     data: Tuple[bytes, ...],
 ) -> BLEGAPAdvertisement:
@@ -167,7 +167,7 @@ def parse_advertisement_data(
     return _cached_parse_advertisement_data(tuple(data))
 
 
-@lru_cache(maxsize=256)
+@lru_cache(maxsize=512)
 def _parse_advertisement_data_tuple(
     data: Tuple[bytes, ...],
 ) -> BLEGAPAdvertisementTupleType:


### PR DESCRIPTION
We keep overrunning the cache and end up doing needless parsing

2023-09-25 15:13:09.704 CRITICAL (SyncWorker_1) [homeassistant.components.profiler] Cache stats for lru_cache <cyfunction _parse_advertisement_data_tuple at 0x7f4d893c98a0> at unknown: CacheInfo(hits=94566, misses=711, maxsize=256, currsize=256)