### PR TITLE
feat: improve performance of gap parser

### DIFF
--- a/src/bluetooth_data_tools/gap.pxd
+++ b/src/bluetooth_data_tools/gap.pxd
@@ -45,10 +45,9 @@ cpdef parse_advertisement_data_tuple(cython.tuple data)
 @cython.locals(
     gap_data=cython.bytes,
     gap_value=cython.bytes,
-    gap_view="const unsigned char [:]",
-    gap_type_num=cython.uint,
+    gap_type_num="unsigned char",
     total_length=cython.uint,
-    length=cython.uint,
+    length="unsigned char",
     offset=cython.uint,
     start=cython.uint,
     end=cython.uint,

--- a/src/bluetooth_data_tools/gap.py
+++ b/src/bluetooth_data_tools/gap.py
@@ -208,19 +208,18 @@ def _uncached_parse_advertisement_data(
     tx_power: int | None = None
 
     for gap_data in data:
-        gap_view = gap_data
         offset = 0
         total_length = len(gap_data)
         while offset < total_length:
             try:
-                length = gap_view[offset]
+                length = gap_data[offset]
                 if not length:
                     if offset + 2 < total_length:
                         # Maybe zero padding
                         offset += 1
                         continue
                     break
-                gap_type_num = gap_view[offset + 1]
+                gap_type_num = gap_data[offset + 1]
                 if not gap_type_num:
                     break
                 start = offset + 2


### PR DESCRIPTION
instead of using a view, use char

before
```
Parsing 100000 bluetooth messages took 0.032907540997257456 seconds
Parsing 100000 bluetooth messages without caching took 1.9759795420104638 seconds
```


after
```
Parsing 100000 bluetooth messages took 0.024532374984119087 seconds
Parsing 100000 bluetooth messages without caching took 1.4332365000154823 seconds
```