### PR TITLE
feat: speed up to gap parser

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
+extend-ignore = E203
 exclude = docs
 max-line-length = 188

--- a/src/bluetooth_data_tools/gap.pxd
+++ b/src/bluetooth_data_tools/gap.pxd
@@ -7,7 +7,6 @@ cdef object from_bytes
 cdef object from_bytes_little
 cdef object from_bytes_signed
 
-cdef object _cached_uint64_bytes_as_uuid
 cdef object _cached_uint16_bytes_as_uuid
 cdef object _cached_uint32_bytes_as_uuid
 cdef object _cached_uint128_bytes_as_uuid

--- a/src/bluetooth_data_tools/gap.py
+++ b/src/bluetooth_data_tools/gap.py
@@ -210,31 +210,28 @@ def _uncached_parse_advertisement_data(
     for gap_data in data:
         offset = 0
         total_length = len(gap_data)
-        while offset < total_length:
-            try:
-                length = gap_data[offset]
-                if not length:
-                    if offset + 2 < total_length:
-                        # Maybe zero padding
-                        offset += 1
-                        continue
-                    break
-                gap_type_num = gap_data[offset + 1]
-                if not gap_type_num:
-                    break
-                start = offset + 2
-                end = start + length - 1
-                gap_value = gap_data[start:end]
-            except IndexError as ex:
+        while offset + 1 < total_length:
+            length = gap_data[offset]
+            if not length:
+                if offset + 2 < total_length:
+                    # Maybe zero padding
+                    offset += 1
+                    continue
+                break
+            gap_type_num = gap_data[offset + 1]
+            if not gap_type_num:
+                break
+            start = offset + 2
+            end = start + length - 1
+            if total_length < end:
                 _LOGGER.debug(
                     "Invalid BLE GAP AD structure at offset %s: %s (%s)",
                     offset,
                     gap_data,
-                    ex,
                 )
                 offset += 1 + length
                 continue
-
+            gap_value = gap_data[start:end]
             offset += 1 + length
             if end - start == 0:
                 continue


### PR DESCRIPTION
This is ~42% speed up to the uncached parser

before

% python3 bench/parse_gap_tuple.py
Parsing 100000 bluetooth messages took 0.023806041994248517 seconds
Parsing 100000 bluetooth messages without caching took 1.3921346249990165 seconds

after

% python3 bench/parse_gap_tuple.py
Parsing 100000 bluetooth messages took 0.022713750004186295 seconds
Parsing 100000 bluetooth messages without caching took 0.8094419999979436 seconds

