### PR TITLE
fix: speed up int_to_bluetooth_address C implementation

### DIFF
--- a/src/bluetooth_data_tools/_utils_impl.pyx
+++ b/src/bluetooth_data_tools/_utils_impl.pyx
@@ -1,22 +1,12 @@
-import cython
+# cython: language_level=3, c_string_type=str, c_string_encoding=ascii
 
-from libc.stdlib cimport malloc
-
-
-cdef extern from "stdint.h":
-    ctypedef unsigned long long uint64_t
+from libc.stdint cimport uint64_t
 
 cdef extern from "utils_wrapper.h":
-    void _uint64_to_bdaddr(uint64_t addr, char *bdaddr)
-
-cdef char* uint64_to_bdaddr(uint64_t address):
-    cdef char* bdaddr = <char *> malloc((18) * sizeof(char))
-    if not bdaddr:
-        return NULL  # malloc failed
-    _uint64_to_bdaddr(address, bdaddr)
-    return bdaddr
-
+    void _uint64_to_bdaddr(uint64_t address, char bdaddr[17]) nogil
 
 
 def _int_to_bluetooth_address(addr: int) -> str:
-    return uint64_to_bdaddr(addr).decode('ascii')
+    cdef char bdaddr[17]
+    _uint64_to_bdaddr(<uint64_t>addr, bdaddr)
+    return <str>bdaddr[:17]

--- a/src/bluetooth_data_tools/utils_wrapper.h
+++ b/src/bluetooth_data_tools/utils_wrapper.h
@@ -1,26 +1,26 @@
-
-
 #include <stdint.h>
-#include <stdio.h>
 
-void _uint64_to_bdaddr(uint64_t address, char *bdaddr) {
+/**
+* Convert the given integer bluetooth address to its hexadecimal string representation.
+* The buffer passed in must accept at least 17 bytes. It will NOT be null-terminated.
+*/
+void _uint64_to_bdaddr(uint64_t address, char bdaddr[17]) {
     static const char hex_table[] = "0123456789ABCDEF";
-    *bdaddr++ = hex_table[(address >> 44) & 0x0F];
-    *bdaddr++ = hex_table[(address >> 40) & 0x0F];
-    *bdaddr++ = ':';
-    *bdaddr++ = hex_table[(address >> 36) & 0x0F];
-    *bdaddr++ = hex_table[(address >> 32) & 0x0F];
-    *bdaddr++ = ':';
-    *bdaddr++ = hex_table[(address >> 28) & 0x0F];
-    *bdaddr++ = hex_table[(address >> 24) & 0x0F];
-    *bdaddr++ = ':';
-    *bdaddr++ = hex_table[(address >> 20) & 0x0F];
-    *bdaddr++ = hex_table[(address >> 16) & 0x0F];
-    *bdaddr++ = ':';
-    *bdaddr++ = hex_table[(address >> 12) & 0x0F];
-    *bdaddr++ = hex_table[(address >> 8) & 0x0F];
-    *bdaddr++ = ':';
-    *bdaddr++ = hex_table[(address >> 4) & 0x0F];
-    *bdaddr++ = hex_table[address & 0x0F];
-    *bdaddr++ = '\0';
+    bdaddr[0] = hex_table[(address >> 44) & 0x0F];
+    bdaddr[1] = hex_table[(address >> 40) & 0x0F];
+    bdaddr[2] = ':';
+    bdaddr[3] = hex_table[(address >> 36) & 0x0F];
+    bdaddr[4] = hex_table[(address >> 32) & 0x0F];
+    bdaddr[5] = ':';
+    bdaddr[6] = hex_table[(address >> 28) & 0x0F];
+    bdaddr[7] = hex_table[(address >> 24) & 0x0F];
+    bdaddr[8] = ':';
+    bdaddr[9] = hex_table[(address >> 20) & 0x0F];
+    bdaddr[10] = hex_table[(address >> 16) & 0x0F];
+    bdaddr[11] = ':';
+    bdaddr[12] = hex_table[(address >> 12) & 0x0F];
+    bdaddr[13] = hex_table[(address >> 8) & 0x0F];
+    bdaddr[14] = ':';
+    bdaddr[15] = hex_table[(address >> 4) & 0x0F];
+    bdaddr[16] = hex_table[address & 0x0F];
 }


### PR DESCRIPTION
Similar to https://github.com/bdraco/ulid-transform/pull/43.

I think the previous implementation also had a memory leak, unless Cython somehow implicitly took care of `free()`ing the mallocated `bdaddr`.

---

Seems to be a 12.5% speed improvement on `test_parse_int_to_bluetooth_address_uncached` on my machine.