### PR TITLE
feat: improve performance of gap parser with empty fields

### DIFF
--- a/src/bluetooth_data_tools/gap.pxd
+++ b/src/bluetooth_data_tools/gap.pxd
@@ -11,13 +11,13 @@ cdef dict _EMPTY_MANUFACTURER_DATA
 cdef dict _EMPTY_SERVICE_DATA
 cdef list _EMPTY_SERVICE_UUIDS
 
-cdef object _cached_uint16_bytes_as_uuid
-cdef object _cached_uint32_bytes_as_uuid
-cdef object _cached_uint128_bytes_as_uuid
+cdef object _uint16_bytes_as_uuid
+cdef object _uint32_bytes_as_uuid
+cdef object _uint128_bytes_as_uuid
+cdef object _manufacturer_id_bytes_to_int
+cdef object _from_bytes_signed
+
 cdef object _cached_parse_advertisement_data
-cdef object _cached_parse_advertisement_data_tuple
-cdef object _cached_manufacturer_id_bytes_to_int
-cdef object _cached_from_bytes_signed
 
 cdef object _LOGGER
 

--- a/src/bluetooth_data_tools/gap.pxd
+++ b/src/bluetooth_data_tools/gap.pxd
@@ -7,6 +7,10 @@ cdef object from_bytes
 cdef object from_bytes_little
 cdef object from_bytes_signed
 
+cdef dict _EMPTY_MANUFACTURER_DATA
+cdef dict _EMPTY_SERVICE_DATA
+cdef list _EMPTY_SERVICE_UUIDS
+
 cdef object _cached_uint16_bytes_as_uuid
 cdef object _cached_uint32_bytes_as_uuid
 cdef object _cached_uint128_bytes_as_uuid
@@ -49,6 +53,5 @@ cpdef parse_advertisement_data(object data)
     offset=cython.uint,
     start=cython.uint,
     end=cython.uint,
-    tx_power_int="unsigned char"
 )
 cpdef _uncached_parse_advertisement_data(tuple data)

--- a/src/bluetooth_data_tools/gap.pxd
+++ b/src/bluetooth_data_tools/gap.pxd
@@ -45,7 +45,7 @@ cpdef parse_advertisement_data(object data)
 
 @cython.locals(
     gap_bytes="bytes",
-    gap_data="const unsigned char *",
+    cstr="const unsigned char *",
     gap_value=cython.bytes,
     gap_type_num="unsigned char",
     total_length=cython.uint,

--- a/src/bluetooth_data_tools/gap.py
+++ b/src/bluetooth_data_tools/gap.py
@@ -173,14 +173,14 @@ def _uncached_parse_advertisement_data(
     for gap_bytes in data:
         offset = 0
         total_length = len(gap_bytes)
-        gap_data = gap_bytes
+        cstr = gap_bytes
         # IMPORTANT: All data must be manually bounds checked
         # because the data is untrusted and can be malformed.
         while offset + 2 < total_length:
-            if not (length := gap_data[offset]):
+            if not (length := cstr[offset]):
                 offset += 1  # Handle zero padding
                 continue
-            if not (gap_type_num := gap_data[offset + 1]):
+            if not (gap_type_num := cstr[offset + 1]):
                 offset += 1 + length  # Skip empty type
                 continue
             start = offset + 2
@@ -195,85 +195,79 @@ def _uncached_parse_advertisement_data(
                 continue
             offset += 1 + length
             if gap_type_num == TYPE_SHORT_LOCAL_NAME and local_name is None:
-                local_name = gap_data[start:end].decode("utf-8", "replace")
+                local_name = cstr[start:end].decode("utf-8", "replace")
             elif gap_type_num == TYPE_COMPLETE_LOCAL_NAME:
-                local_name = gap_data[start:end].decode("utf-8", "replace")
+                local_name = cstr[start:end].decode("utf-8", "replace")
             elif gap_type_num == TYPE_MANUFACTURER_SPECIFIC_DATA:
                 if start + 2 >= total_length:
                     break
                 if manufacturer_data is None:
                     manufacturer_data = {
                         _cached_manufacturer_id_bytes_to_int(
-                            gap_data[start : start + 2]
-                        ): gap_data[start + 2 : end]
+                            cstr[start : start + 2]
+                        ): cstr[start + 2 : end]
                     }
                 else:
                     manufacturer_data[
-                        _cached_manufacturer_id_bytes_to_int(
-                            gap_data[start : start + 2]
-                        )
-                    ] = gap_data[start + 2 : end]
+                        _cached_manufacturer_id_bytes_to_int(cstr[start : start + 2])
+                    ] = cstr[start + 2 : end]
             elif gap_type_num in {
                 TYPE_16BIT_SERVICE_UUID_COMPLETE,
                 TYPE_16BIT_SERVICE_UUID_MORE_AVAILABLE,
             }:
                 if service_uuids is None:
-                    service_uuids = [_cached_uint16_bytes_as_uuid(gap_data[start:end])]
+                    service_uuids = [_cached_uint16_bytes_as_uuid(cstr[start:end])]
                 else:
-                    service_uuids.append(
-                        _cached_uint16_bytes_as_uuid(gap_data[start:end])
-                    )
+                    service_uuids.append(_cached_uint16_bytes_as_uuid(cstr[start:end]))
             elif gap_type_num in {
                 TYPE_128BIT_SERVICE_UUID_MORE_AVAILABLE,
                 TYPE_128BIT_SERVICE_UUID_COMPLETE,
             }:
                 if service_uuids is None:
-                    service_uuids = [_cached_uint128_bytes_as_uuid(gap_data[start:end])]
+                    service_uuids = [_cached_uint128_bytes_as_uuid(cstr[start:end])]
                 else:
-                    service_uuids.append(
-                        _cached_uint128_bytes_as_uuid(gap_data[start:end])
-                    )
+                    service_uuids.append(_cached_uint128_bytes_as_uuid(cstr[start:end]))
             elif gap_type_num == TYPE_SERVICE_DATA:
                 if start + 2 >= total_length:
                     break
                 if service_data is None:
                     service_data = {
-                        _cached_uint16_bytes_as_uuid(
-                            gap_data[start : start + 2]
-                        ): gap_data[start + 2 : end]
+                        _cached_uint16_bytes_as_uuid(cstr[start : start + 2]): cstr[
+                            start + 2 : end
+                        ]
                     }
                 else:
                     service_data[
-                        _cached_uint16_bytes_as_uuid(gap_data[start : start + 2])
-                    ] = gap_data[start + 2 : end]
+                        _cached_uint16_bytes_as_uuid(cstr[start : start + 2])
+                    ] = cstr[start + 2 : end]
             elif gap_type_num == TYPE_SERVICE_DATA_32BIT_UUID:
                 if start + 4 >= total_length:
                     break
                 if service_data is None:
                     service_data = {
-                        _cached_uint32_bytes_as_uuid(
-                            gap_data[start : start + 4]
-                        ): gap_data[start + 4 : end]
+                        _cached_uint32_bytes_as_uuid(cstr[start : start + 4]): cstr[
+                            start + 4 : end
+                        ]
                     }
                 else:
                     service_data[
-                        _cached_uint32_bytes_as_uuid(gap_data[start : start + 4])
-                    ] = gap_data[start + 4 : end]
+                        _cached_uint32_bytes_as_uuid(cstr[start : start + 4])
+                    ] = cstr[start + 4 : end]
             elif gap_type_num == TYPE_SERVICE_DATA_128BIT_UUID:
                 if start + 16 >= total_length:
                     break
                 if service_data is None:
                     service_data = {
-                        _cached_uint128_bytes_as_uuid(
-                            gap_data[start : start + 16]
-                        ): gap_data[start + 16 : end]
+                        _cached_uint128_bytes_as_uuid(cstr[start : start + 16]): cstr[
+                            start + 16 : end
+                        ]
                     }
                 else:
                     service_data[
-                        _cached_uint128_bytes_as_uuid(gap_data[start : start + 16])
-                    ] = gap_data[start + 16 : end]
+                        _cached_uint128_bytes_as_uuid(cstr[start : start + 16])
+                    ] = cstr[start + 16 : end]
             elif gap_type_num == TYPE_TX_POWER_LEVEL:
-                tx_power = _cached_from_bytes_signed(gap_data[start:end])
+                tx_power = _cached_from_bytes_signed(cstr[start:end])
 
     return (
         local_name,

--- a/src/bluetooth_data_tools/gap.py
+++ b/src/bluetooth_data_tools/gap.py
@@ -156,12 +156,17 @@ def parse_advertisement_data(
     return _cached_parse_advertisement_data(tuple(data))
 
 
+_EMPTY_MANUFACTURER_DATA: dict[int, bytes] = {}
+_EMPTY_SERVICE_DATA: dict[str, bytes] = {}
+_EMPTY_SERVICE_UUIDS: list[str] = []
+
+
 def _uncached_parse_advertisement_data(
     data: tuple[bytes, ...],
 ) -> BLEGAPAdvertisementTupleType:
-    manufacturer_data: dict[int, bytes] = {}
-    service_data: dict[str, bytes] = {}
-    service_uuids: list[str] = []
+    manufacturer_data = _EMPTY_MANUFACTURER_DATA
+    service_data = _EMPTY_SERVICE_DATA
+    service_uuids = _EMPTY_SERVICE_UUIDS
     local_name: str | None = None
     tx_power: int | None = None
 
@@ -196,6 +201,8 @@ def _uncached_parse_advertisement_data(
             elif gap_type_num == TYPE_MANUFACTURER_SPECIFIC_DATA:
                 if start + 2 >= total_length:
                     break
+                if manufacturer_data is _EMPTY_MANUFACTURER_DATA:
+                    manufacturer_data = {}
                 manufacturer_data[
                     _cached_manufacturer_id_bytes_to_int(gap_data[start : start + 2])
                 ] = gap_data[start + 2 : end]
@@ -203,27 +210,37 @@ def _uncached_parse_advertisement_data(
                 TYPE_16BIT_SERVICE_UUID_COMPLETE,
                 TYPE_16BIT_SERVICE_UUID_MORE_AVAILABLE,
             }:
+                if service_uuids is _EMPTY_SERVICE_UUIDS:
+                    service_uuids = []
                 service_uuids.append(_cached_uint16_bytes_as_uuid(gap_data[start:end]))
             elif gap_type_num in {
                 TYPE_128BIT_SERVICE_UUID_MORE_AVAILABLE,
                 TYPE_128BIT_SERVICE_UUID_COMPLETE,
             }:
+                if service_uuids is _EMPTY_SERVICE_UUIDS:
+                    service_uuids = []
                 service_uuids.append(_cached_uint128_bytes_as_uuid(gap_data[start:end]))
             elif gap_type_num == TYPE_SERVICE_DATA:
                 if start + 2 >= total_length:
                     break
+                if service_data is _EMPTY_SERVICE_DATA:
+                    service_data = {}
                 service_data[
                     _cached_uint16_bytes_as_uuid(gap_data[start : start + 2])
                 ] = gap_data[start + 2 : end]
             elif gap_type_num == TYPE_SERVICE_DATA_32BIT_UUID:
                 if start + 4 >= total_length:
                     break
+                if service_data is _EMPTY_SERVICE_DATA:
+                    service_data = {}
                 service_data[
                     _cached_uint32_bytes_as_uuid(gap_data[start : start + 4])
                 ] = gap_data[start + 4 : end]
             elif gap_type_num == TYPE_SERVICE_DATA_128BIT_UUID:
                 if start + 16 >= total_length:
                     break
+                if service_data is _EMPTY_SERVICE_DATA:
+                    service_data = {}
                 service_data[
                     _cached_uint128_bytes_as_uuid(gap_data[start : start + 16])
                 ] = gap_data[start + 16 : end]

--- a/src/bluetooth_data_tools/gap.py
+++ b/src/bluetooth_data_tools/gap.py
@@ -202,48 +202,76 @@ def _uncached_parse_advertisement_data(
                 if start + 2 >= total_length:
                     break
                 if manufacturer_data is None:
-                    manufacturer_data = {}
-                manufacturer_data[
-                    _cached_manufacturer_id_bytes_to_int(gap_data[start : start + 2])
-                ] = gap_data[start + 2 : end]
+                    manufacturer_data = {
+                        _cached_manufacturer_id_bytes_to_int(
+                            gap_data[start : start + 2]
+                        ): gap_data[start + 2 : end]
+                    }
+                else:
+                    manufacturer_data[
+                        _cached_manufacturer_id_bytes_to_int(
+                            gap_data[start : start + 2]
+                        )
+                    ] = gap_data[start + 2 : end]
             elif gap_type_num in {
                 TYPE_16BIT_SERVICE_UUID_COMPLETE,
                 TYPE_16BIT_SERVICE_UUID_MORE_AVAILABLE,
             }:
                 if service_uuids is None:
-                    service_uuids = []
-                service_uuids.append(_cached_uint16_bytes_as_uuid(gap_data[start:end]))
+                    service_uuids = [_cached_uint16_bytes_as_uuid(gap_data[start:end])]
+                else:
+                    service_uuids.append(
+                        _cached_uint16_bytes_as_uuid(gap_data[start:end])
+                    )
             elif gap_type_num in {
                 TYPE_128BIT_SERVICE_UUID_MORE_AVAILABLE,
                 TYPE_128BIT_SERVICE_UUID_COMPLETE,
             }:
                 if service_uuids is None:
-                    service_uuids = []
-                service_uuids.append(_cached_uint128_bytes_as_uuid(gap_data[start:end]))
+                    service_uuids = [_cached_uint128_bytes_as_uuid(gap_data[start:end])]
+                else:
+                    service_uuids.append(
+                        _cached_uint128_bytes_as_uuid(gap_data[start:end])
+                    )
             elif gap_type_num == TYPE_SERVICE_DATA:
                 if start + 2 >= total_length:
                     break
                 if service_data is None:
-                    service_data = {}
-                service_data[
-                    _cached_uint16_bytes_as_uuid(gap_data[start : start + 2])
-                ] = gap_data[start + 2 : end]
+                    service_data = {
+                        _cached_uint16_bytes_as_uuid(
+                            gap_data[start : start + 2]
+                        ): gap_data[start + 2 : end]
+                    }
+                else:
+                    service_data[
+                        _cached_uint16_bytes_as_uuid(gap_data[start : start + 2])
+                    ] = gap_data[start + 2 : end]
             elif gap_type_num == TYPE_SERVICE_DATA_32BIT_UUID:
                 if start + 4 >= total_length:
                     break
                 if service_data is None:
-                    service_data = {}
-                service_data[
-                    _cached_uint32_bytes_as_uuid(gap_data[start : start + 4])
-                ] = gap_data[start + 4 : end]
+                    service_data = {
+                        _cached_uint32_bytes_as_uuid(
+                            gap_data[start : start + 4]
+                        ): gap_data[start + 4 : end]
+                    }
+                else:
+                    service_data[
+                        _cached_uint32_bytes_as_uuid(gap_data[start : start + 4])
+                    ] = gap_data[start + 4 : end]
             elif gap_type_num == TYPE_SERVICE_DATA_128BIT_UUID:
                 if start + 16 >= total_length:
                     break
                 if service_data is None:
-                    service_data = {}
-                service_data[
-                    _cached_uint128_bytes_as_uuid(gap_data[start : start + 16])
-                ] = gap_data[start + 16 : end]
+                    service_data = {
+                        _cached_uint128_bytes_as_uuid(
+                            gap_data[start : start + 16]
+                        ): gap_data[start + 16 : end]
+                    }
+                else:
+                    service_data[
+                        _cached_uint128_bytes_as_uuid(gap_data[start : start + 16])
+                    ] = gap_data[start + 16 : end]
             elif gap_type_num == TYPE_TX_POWER_LEVEL:
                 tx_power = _cached_from_bytes_signed(gap_data[start:end])
 

--- a/tests/test_gap.py
+++ b/tests/test_gap.py
@@ -211,6 +211,24 @@ def test_parse_advertisement_data_128bit_service_data():
     assert adv.tx_power is None
 
 
+def test_parse_advertisement_data_32_and_128bit_service_data():
+    data = [
+        b"\x07\x20\x1a\x02\n\x05\n\xff"
+        + b"\x12\x21\x1a\x02\n\x05\n\xff\x062k\x03R\x00\x01\x04\t\x00\x04",
+    ]
+
+    adv = parse_advertisement_data(data)
+
+    assert adv.local_name is None
+    assert adv.service_uuids == []
+    assert adv.service_data == {
+        "00090401-0052-036b-3206-ff0a050a021a": b"\x04",
+        "050a021a-0000-1000-8000-00805f9b34fb": b"\n\xff",
+    }
+    assert adv.manufacturer_data == {}
+    assert adv.tx_power is None
+
+
 def test_parse_advertisement_data_128bit_service_data_tuple():
     data = (b"\x12\x21\x1a\x02\n\x05\n\xff\x062k\x03R\x00\x01\x04\t\x00\x04",)
 

--- a/tests/test_gap.py
+++ b/tests/test_gap.py
@@ -229,6 +229,24 @@ def test_parse_advertisement_data_32_and_128bit_service_data():
     assert adv.tx_power is None
 
 
+def test_parse_advertisement_data_128_and_32bit_service_data():
+    data = [
+        b"\x12\x21\x1a\x02\n\x05\n\xff\x062k\x03R\x00\x01\x04\t\x00\x04"
+        + b"\x07\x20\x1a\x02\n\x05\n\xff"
+    ]
+
+    adv = parse_advertisement_data(data)
+
+    assert adv.local_name is None
+    assert adv.service_uuids == []
+    assert adv.service_data == {
+        "050a021a-0000-1000-8000-00805f9b34fb": b"\n\xff",
+        "00090401-0052-036b-3206-ff0a050a021a": b"\x04",
+    }
+    assert adv.manufacturer_data == {}
+    assert adv.tx_power is None
+
+
 def test_parse_advertisement_data_128bit_service_data_tuple():
     data = (b"\x12\x21\x1a\x02\n\x05\n\xff\x062k\x03R\x00\x01\x04\t\x00\x04",)
 

--- a/tests/test_gap.py
+++ b/tests/test_gap.py
@@ -386,6 +386,39 @@ def test_name_parser():
     )
 
 
+def test_name_parser_with_16_bit_uuid_first():
+    """Test parsing name from https://github.com/esphome/issues/issues/4838."""
+
+    data = (
+        b"\x02\x01\x06\t\xffY\x00\xfe\x024\x9e\xa6\xba\x00\x00\x00\x00\x00\x00\x00\x00"
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x07\x1b\xc5\xd5\xa5\x02\x00\xb8"
+        b'\x9f\xe6\x11M"\x00\r\xa2\xcb\x06\x16\x00\rH\x10\x00\x00\x00\x00\x00\x00\x00'
+        b"\t\tPineTime\002\001\006\021\007\236\312\334$\016\345\251(340\223\363\243\265\001\000@n",
+    )
+
+    adv = parse_advertisement_data(data)
+
+    assert adv.local_name == "PineTime"
+    assert adv.service_uuids == [
+        "cba20d00-224d-11e6-9fb8-0002a5d5c51b",
+        "01b5a3f3-9330-3433-28a9-e50e24dcca9e",
+    ]
+    assert adv.service_data == {"00000d00-0000-1000-8000-00805f9b34fb": b"H\x10\x00"}
+    assert adv.manufacturer_data == {89: b"\xfe\x024\x9e\xa6\xba"}
+    assert adv.tx_power is None
+
+    assert parse_advertisement_data_tuple(tuple(data)) == (
+        "PineTime",
+        [
+            "cba20d00-224d-11e6-9fb8-0002a5d5c51b",
+            "01b5a3f3-9330-3433-28a9-e50e24dcca9e",
+        ],
+        {"00000d00-0000-1000-8000-00805f9b34fb": b"H\x10\x00"},
+        {89: b"\xfe\x024\x9e\xa6\xba"},
+        None,
+    )
+
+
 def test_invalid_gap_num():
     """Test skip invalid gap type."""
 


### PR DESCRIPTION
This will help `habluetooth` but won't show any performance change here

There is a bit of a risk that downstream might modify these since they are mutable. If that turns out to be a problem we can make them readonly