### PR TITLE
fix: increase size of parse_advertisement_data_tuple cache to 1024

### DIFF
--- a/src/bluetooth_data_tools/gap.py
+++ b/src/bluetooth_data_tools/gap.py
@@ -255,6 +255,6 @@ if TYPE_CHECKING:
         """
         return _uncached_parse_advertisement_data(data)
 else:
-    parse_advertisement_data_tuple = lru_cache(maxsize=256)(
+    parse_advertisement_data_tuple = lru_cache(maxsize=1024)(
         _uncached_parse_advertisement_data
     )


### PR DESCRIPTION
fixes #123

This one churns quite a bit and from how often its called, its a drain on performance having it so small.