### PR TITLE
feat: improve performance of parsing manufacturer_data

### DIFF
--- a/src/bluetooth_data_tools/gap.pxd
+++ b/src/bluetooth_data_tools/gap.pxd
@@ -12,7 +12,6 @@ cdef object _cached_uint32_bytes_as_uuid
 cdef object _cached_uint128_bytes_as_uuid
 cdef object _cached_parse_advertisement_data
 cdef object _cached_parse_advertisement_data_tuple
-cdef object _cached_manufacturer_id_bytes_to_int
 cdef object _cached_from_bytes_signed
 
 cdef object _LOGGER

--- a/src/bluetooth_data_tools/gap.py
+++ b/src/bluetooth_data_tools/gap.py
@@ -133,8 +133,6 @@ def _uint32_bytes_as_uuid(uuid32_bytes: bytes_) -> str:
 
 _cached_uint32_bytes_as_uuid = _uint32_bytes_as_uuid
 
-_cached_manufacturer_id_bytes_to_int = lru_cache(maxsize=256)(from_bytes_little)
-
 
 @lru_cache(maxsize=256)
 def _parse_advertisement_data(
@@ -196,9 +194,9 @@ def _uncached_parse_advertisement_data(
                 splice_pos = start + 2
                 if splice_pos >= total_length or splice_pos >= end:
                     break
-                manufacturer_data[
-                    _cached_manufacturer_id_bytes_to_int(gap_data[start:splice_pos])
-                ] = gap_data[splice_pos:end]
+                manufacturer_data[gap_data[start] | (gap_data[start + 1] << 8)] = (
+                    gap_data[splice_pos:end]
+                )
             elif gap_type_num in {
                 TYPE_16BIT_SERVICE_UUID_COMPLETE,
                 TYPE_16BIT_SERVICE_UUID_MORE_AVAILABLE,


### PR DESCRIPTION
- Its always little endian
- We return a PyInt
- The cache is more expensive than converting the C int to Py