### PR TITLE
ci(release): use release-bot GitHub App token for PSR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,10 @@ jobs:
       - commitlint
 
     runs-on: ubuntu-latest
-    environment: release
+    # Only enter the protected 'release' environment when actually releasing
+    # from main; PR dry-runs would otherwise be blocked by the env's
+    # main-only branch policy.
+    environment: ${{ github.ref_name == 'main' && 'release' || '' }}
     concurrency: release
     permissions:
       id-token: write
@@ -143,14 +146,28 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref || github.ref_name }}
+          ref: ${{ github.ref }}
+
+      - name: Create local branch name
+        run: git switch -C ${{ github.head_ref || github.ref_name }}
 
       # Do a dry run of PSR
       - name: Test release
         uses: python-semantic-release/python-semantic-release@v10.5.3
         if: github.ref_name != 'main'
         with:
-          root_options: --noop
+          no_operation_mode: true
+
+      # Mint a short-lived installation token for the release-bot GitHub
+      # App, which is in the main ruleset's bypass_actors list so PSR's
+      # version-bump commit/tag push isn't blocked by required checks.
+      - name: Generate release App token
+        if: github.ref_name == 'main'
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       # On main branch: actual PSR + upload to PyPI & GitHub
       - name: Release
@@ -158,7 +175,7 @@ jobs:
         id: release
         if: github.ref_name == 'main'
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -168,7 +185,7 @@ jobs:
         uses: python-semantic-release/upload-to-gh-release@main
         if: steps.release.outputs.released == 'true'
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
 
   build_wheels:
     needs: [release]


### PR DESCRIPTION
## Summary
- Mint a short-lived installation token via the `bluetooth-data-tools-release-boot` GitHub App (app id `3736171`) and pass it to PSR so the version-bump commit and tag push can bypass the `main` branch's required-checks ruleset (the App is already in `bypass_actors`).
- Gate entry into the protected `release` environment on `github.ref_name == 'main'` so PR dry-runs aren't blocked by the env's main-only branch policy.
- Switch the PSR dry-run from `root_options: --noop` to `no_operation_mode: true` and check out via `${{ github.ref }}` + `git switch -C` to match the working pattern used in `aiodiscover`.

Secrets `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` are already configured in the `release` environment.

## Test plan
- [ ] On this PR: `release` job runs the PSR dry-run step (no env, no App token) and passes.
- [ ] After merge to `main`: `release` job enters the `release` env, mints an App token, and PSR pushes the version-bump commit/tag successfully past required checks.
- [ ] Resulting tag triggers `build_wheels` + `upload_pypi` and the new version lands on PyPI and the GH release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)