### PR TITLE
ci(release): pass release App token to actions/checkout as well as PSR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,10 +143,26 @@ jobs:
       newest_release_tag: ${{ steps.release.outputs.tag }}
 
     steps:
+      # Mint a short-lived installation token for the release-bot GitHub
+      # App, which is in the main ruleset's bypass_actors list so PSR's
+      # version-bump commit/tag push isn't blocked by required checks.
+      # Per PSR's docs, the same token must be passed to actions/checkout
+      # (via `token`) so its persisted http.extraheader doesn't override
+      # PSR's URL-embedded auth at push time and re-attribute the push
+      # to github-actions[bot].
+      - name: Generate release App token
+        if: github.ref_name == 'main'
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Create local branch name
         run: git switch -C ${{ github.head_ref || github.ref_name }}
@@ -157,17 +173,6 @@ jobs:
         if: github.ref_name != 'main'
         with:
           no_operation_mode: true
-
-      # Mint a short-lived installation token for the release-bot GitHub
-      # App, which is in the main ruleset's bypass_actors list so PSR's
-      # version-bump commit/tag push isn't blocked by required checks.
-      - name: Generate release App token
-        if: github.ref_name == 'main'
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       # On main branch: actual PSR + upload to PyPI & GitHub
       - name: Release


### PR DESCRIPTION
## Summary

Follow-up to #228. PSR's commit/tag push was being authenticated correctly **at the URL level** with the App token, but `actions/checkout` had also persisted the default `GITHUB_TOKEN` into the workspace's local git config as `http.https://github.com/.extraheader`. At push time, git sends *both* the URL-embedded basic auth and the extraheader, and GitHub honors the extraheader — so the push landed as `github-actions[bot]`, which isn't in the ruleset bypass list, and got rejected with `GH013` again.

This is the exact failure mode the [aiodiscover fix in #203](https://github.com/Bluetooth-Devices/aiodiscover/pull/203) called out.

## Fix (PSR-documented)

[PSR's GitHub Actions docs](https://python-semantic-release.readthedocs.io/en/stable/configuration/automatic-releases/github-actions.html) call this out under the `GITHUB_TOKEN` warning:

> You can work around this by storing an administrator's Personal Access Token as a separate secret and using that instead of `GITHUB_TOKEN`. **In this case, you will also need to pass the new token to `actions/checkout` (as the `token` input)** in order to gain push access.

So:

- Move the `actions/create-github-app-token@v2` step **before** `actions/checkout`.
- Pass `${{ steps.app-token.outputs.token }}` to `actions/checkout`'s `token:` input (with a `|| github.token` fallback so PR dry-runs, which skip the App-token step, still authenticate the clone).

Both the persisted extraheader and PSR's URL auth now use the App token, so the push is attributed to `bluetooth-data-tools-release-boot[bot]`, which is in `bypass_actors`.

## Prerequisites

The App + secrets + bypass-list setup from #228 is already in place — no extra GitHub-side configuration needed.

## Test plan

- [ ] Merge and confirm the release job pushes the next version-bump commit + tag to \`main\` as \`bluetooth-data-tools-release-boot[bot]\`, then uploads wheels to PyPI and creates the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)