### PR TITLE
perf(build): parallelize cython extension compilation

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -45,6 +45,8 @@ EXTENSIONS = [
 
 class BuildExt(build_ext):
     def build_extensions(self) -> None:
+        if self.parallel is None:  # type: ignore[has-type, unused-ignore]
+            self.parallel = os.cpu_count() or 1
         try:
             super().build_extensions()
         except Exception:  # noqa: S110


### PR DESCRIPTION
Default `BuildExt.parallel` to `os.cpu_count()` so per-module `gcc` compilations run in parallel instead of one at a time; the QEMU emulated wheel jobs are the biggest beneficiary.

Mirrors Bluetooth-Devices/habluetooth#421, python-zeroconf/python-zeroconf#1689.