### PR TITLE
ci(wheels): swap retired macos-13 runner for macos-15-intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
             windows-latest,
             ubuntu-24.04-arm,
             ubuntu-latest,
-            macos-13,
+            macos-15-intel,
             macos-latest,
           ]
         qemu: [""]


### PR DESCRIPTION
## Summary

GitHub retired the macos-13 image. The "Wheels for macos-13" matrix entry has been stuck in the queued state on every release since 1.29.0, which prevents the build_wheels job from completing, which in turn prevents upload_pypi from running. As a result the cibuildwheel artifacts never reach PyPI, and the only file published for 1.29.0 through 1.29.4 is the single cp314 manylinux wheel that PSR happens to build inside its own release step.

macos-15-intel is GitHub's current x86_64 macOS runner and is the documented replacement.

## Test plan

* [ ] Merge to main, watch for PSR to cut the next release
* [ ] Confirm the macos-15-intel matrix job picks up and builds x86_64 macOS wheels
* [ ] Confirm upload_pypi runs and that the new version on PyPI lists wheels for all matrix targets like 1.28.4 did