### PR TITLE
fix(ci): allow forcing a release via workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,19 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Force a release of this version type (passes through to python-semantic-release)"
+        required: false
+        default: ""
+        type: choice
+        options:
+          - ""
+          - patch
+          - minor
+          - major
+          - prerelease
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -181,6 +194,7 @@ jobs:
         if: github.ref_name == 'main'
         with:
           github_token: ${{ steps.app-token.outputs.token }}
+          force: ${{ inputs.force }}
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` trigger to the CI workflow with a `force` input wired through to python-semantic-release. This gives us a permanent way to manually cut a release when the commits on main don't match PSR's release triggering conventional commit types (feat, fix, perf), or when we need to republish wheels after a CI-side fix.

Using the `fix(ci):` prefix here so that merging this PR itself triggers a 1.29.5 release. That release will exercise the build_wheels matrix with the macos-15-intel replacement from #232 and populate the full wheel set on PyPI for the first time since 1.28.4.

## Test plan

* [ ] Merge to main
* [ ] Watch PSR cut 1.29.5
* [ ] Confirm the build_wheels matrix completes including macos-15-intel
* [ ] Confirm upload_pypi runs and PyPI lists wheels for all the targets that 1.28.4 had
* [ ] Sanity check: run the workflow manually via the Actions tab with force=patch on a later quiet day to confirm the manual lever works