### PR TITLE
build: compile native extensions with -std=gnu2x

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -48,7 +48,7 @@ class BuildExt(build_ext):
         if self.parallel is None:  # type: ignore[has-type, unused-ignore]
             self.parallel = os.cpu_count() or 1
         std_flag = (
-            "/std:clatest" if self.compiler.compiler_type == "msvc" else "-std=c23"
+            "/std:clatest" if self.compiler.compiler_type == "msvc" else "-std=gnu23"
         )
         for ext in self.extensions:
             if std_flag not in ext.extra_compile_args:

--- a/build_ext.py
+++ b/build_ext.py
@@ -48,7 +48,7 @@ class BuildExt(build_ext):
         if self.parallel is None:  # type: ignore[has-type, unused-ignore]
             self.parallel = os.cpu_count() or 1
         std_flag = (
-            "/std:clatest" if self.compiler.compiler_type == "msvc" else "-std=gnu23"
+            "/std:clatest" if self.compiler.compiler_type == "msvc" else "-std=gnu2x"
         )
         for ext in self.extensions:
             if std_flag not in ext.extra_compile_args:

--- a/build_ext.py
+++ b/build_ext.py
@@ -47,6 +47,12 @@ class BuildExt(build_ext):
     def build_extensions(self) -> None:
         if self.parallel is None:  # type: ignore[has-type, unused-ignore]
             self.parallel = os.cpu_count() or 1
+        std_flag = (
+            "/std:clatest" if self.compiler.compiler_type == "msvc" else "-std=c23"
+        )
+        for ext in self.extensions:
+            if std_flag not in ext.extra_compile_args:
+                ext.extra_compile_args = [*ext.extra_compile_args, std_flag]
         try:
             super().build_extensions()
         except Exception:  # noqa: S110


### PR DESCRIPTION
Set `-std=gnu2x` (or `/std:clatest` on MSVC) on every native extension so we can use C23 features such as `constexpr` in headers like `utils_wrapper.h`. Prereq for the `BDADDR_PARSE_ERROR` cleanup in #237.

`gnu2x` works on GCC 11+ (ubuntu-latest ships GCC 13 by default; the `c23`/`gnu23` aliases only landed in GCC 14) and Clang 9+, and the `gnu` variant keeps glibc's inline `memcpy`, `memchr` fast paths enabled, which strict `c23` would have hidden via `__STRICT_ANSI__`.