### PR TITLE
ci: cache poetry venv keyed on lockfile and cython sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  POETRY_VIRTUALENVS_IN_PROJECT: "true"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -71,7 +74,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
       - uses: snok/install-poetry@v1.4.1
+      - name: Cache poetry venv
+        id: cache-venv
+        uses: actions/cache@v5
+        with:
+          path: |
+            .venv
+            src/bluetooth_data_tools/**/*.so
+          key: venv-v1-${{ runner.os }}-py${{ matrix.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/bluetooth_data_tools/**/*.py', 'src/bluetooth_data_tools/**/*.pyx', 'src/bluetooth_data_tools/**/*.pxd') }}
       - name: Install Dependencies
+        if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
           if [ "${{ matrix.extension }}" = "skip_cython" ]; then
             SKIP_CYTHON=1 poetry install --only=main,dev
@@ -103,7 +115,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - uses: snok/install-poetry@v1.4.1
+      - name: Cache poetry venv
+        id: cache-venv
+        uses: actions/cache@v5
+        with:
+          path: |
+            .venv
+            src/bluetooth_data_tools/**/*.so
+          key: venv-v1-${{ runner.os }}-benchmark-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/bluetooth_data_tools/**/*.py', 'src/bluetooth_data_tools/**/*.pyx', 'src/bluetooth_data_tools/**/*.pxd') }}
       - name: Install Dependencies
+        if: steps.cache-venv.outputs.cache-hit != 'true'
         run: poetry install --only=main,dev,benchmark
         env:
           REQUIRE_CYTHON: 1


### PR DESCRIPTION
## What

Caches the poetry-managed `.venv` plus the built Cython artefacts (`src/bluetooth_data_tools/**/*.so`) for both the `test` matrix and the `benchmark` job, keyed on:

- runner OS, python version, extension mode (`skip_cython` / `use_cython` for `test`; `benchmark` is single-mode)
- `hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/bluetooth_data_tools/**/*.py', 'src/bluetooth_data_tools/**/*.pyx', 'src/bluetooth_data_tools/**/*.pxd')`

On a cache hit the `Install Dependencies` step is skipped via `if: steps.cache-venv.outputs.cache-hit != 'true'`. Any change to deps, build script, or compiled sources invalidates the key so we never run tests against stale `.so` files.

`POETRY_VIRTUALENVS_IN_PROJECT: "true"` is set at workflow level so poetry creates `.venv` inside the repo (single cacheable path), and applies to any future job that needs it.

## Why

Without this, `poetry install --only=main,dev` runs on every job in the matrix, and `use_cython` rows rebuild the extensions every time. The test matrix here is 6 python versions, 3 OSes, 2 extension modes; PRs that touch tests or docs were paying the full install cost on every cell.

With this in place, runs where neither `poetry.lock` nor any Cythonized source has changed reuse the prebuilt venv plus `.so` files and skip the install step entirely.

## Notes

Cython sources for this repo are a mix of `.pyx`, `.pxd`, and `.py` (via `TO_CYTHONIZE` in `build_ext.py`), so all three globs are hashed; that matches what `build_ext.py` compiles.

Mirrors Bluetooth-Devices/dbus-fast#675 with #679's cleanups folded in (single hashFiles call, workflow-level env).