### PR TITLE
ci: use astral setup-uv to provision Python and poetry for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           path: |
             .venv
             src/bluetooth_data_tools/**/*.so
-          key: venv-v1-${{ runner.os }}-py${{ matrix.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/bluetooth_data_tools/**/*.py', 'src/bluetooth_data_tools/**/*.pyx', 'src/bluetooth_data_tools/**/*.pxd') }}
+          key: venv-v2-${{ runner.os }}-py${{ matrix.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/bluetooth_data_tools/**/*.py', 'src/bluetooth_data_tools/**/*.pyx', 'src/bluetooth_data_tools/**/*.pxd') }}
       - name: Install Dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -125,7 +125,7 @@ jobs:
           path: |
             .venv
             src/bluetooth_data_tools/**/*.so
-          key: venv-v1-${{ runner.os }}-benchmark-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/bluetooth_data_tools/**/*.py', 'src/bluetooth_data_tools/**/*.pyx', 'src/bluetooth_data_tools/**/*.pxd') }}
+          key: venv-v2-${{ runner.os }}-benchmark-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/bluetooth_data_tools/**/*.py', 'src/bluetooth_data_tools/**/*.pyx', 'src/bluetooth_data_tools/**/*.pxd') }}
       - name: Install Dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: poetry install --only=main,dev,benchmark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,14 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
-          python-version: ${{ matrix.python-version }}
       - name: Install poetry
         run: uv tool install poetry
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+          cache: "poetry"
       - name: Cache poetry venv
         id: cache-venv
         uses: actions/cache@v5
@@ -115,9 +120,13 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
-          python-version: ${{ matrix.python-version }}
       - name: Install poetry
         run: uv tool install poetry
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "poetry"
       - name: Cache poetry venv
         id: cache-venv
         uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
         with:
+          enable-cache: true
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
-      - uses: snok/install-poetry@v1.4.1
+      - name: Install poetry
+        run: uv tool install poetry
       - name: Cache poetry venv
         id: cache-venv
         uses: actions/cache@v5
@@ -110,11 +111,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
         with:
+          enable-cache: true
           python-version: ${{ matrix.python-version }}
-      - uses: snok/install-poetry@v1.4.1
+      - name: Install poetry
+        run: uv tool install poetry
       - name: Cache poetry venv
         id: cache-venv
         uses: actions/cache@v5
@@ -141,11 +144,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+      - name: Install poetry
+        run: uv tool install poetry
       - name: Setup Python 3.13
         uses: actions/setup-python@v6
         with:
           python-version: 3.13
-      - uses: snok/install-poetry@v1.4.1
+          cache: "poetry"
       - name: Install Dependencies
         run: |
           REQUIRE_CYTHON=1 poetry install --only=main,dev


### PR DESCRIPTION
## What

Swap the test and benchmark jobs from `actions/setup-python` plus `snok/install-poetry` over to `astral-sh/setup-uv`, which provisions both Python and poetry. The codspeed job keeps `actions/setup-python` since codspeed needs the standard interpreter; uv just installs poetry for it.

## Why

uv is faster and brings a shared download cache, so warm runs skip the Python install entirely; it also matches the pattern we already use in dbus-fast, aioesphomeapi, and bleak-esphome, so the CI shape stays consistent across the sibling repos.

## How

Each test and benchmark runner now sets up uv with `enable-cache: true` and the matrix's `python-version`, then installs poetry via `uv tool install poetry`; the existing `.venv` cache, `poetry install`, and pytest/codspeed steps are unchanged. The codspeed job adds `cache: "poetry"` on `setup-python` to mirror the bleak-esphome shape.

## Testing

Workflow change only, will be exercised by CI on this PR.