### PR TITLE
test(bench): cover parse_advertisement_data_tuple bytes cache fallthrough

### DIFF
--- a/bench/test_parse_gap_tuple.py
+++ b/bench/test_parse_gap_tuple.py
@@ -89,3 +89,16 @@ def test_parse_advertisement_data_tuple(benchmark):
 def test_parse_advertisement_data_tuple_uncached(benchmark):
     joined_advs = b"".join(advs)
     benchmark(lambda: _uncached_parse_advertisement_data(joined_advs))
+
+
+def test_parse_advertisement_data_tuple_bytes_cache_fallthrough(benchmark):
+    from bluetooth_data_tools import parse_advertisement_data_bytes
+
+    joined = b"".join(advs)
+    parse_advertisement_data_bytes(joined)
+
+    def run():
+        parse_advertisement_data_tuple.cache_clear()
+        parse_advertisement_data_tuple(advs)
+
+    benchmark(run)

--- a/tests/benchmarks/test_parse_gap_tuple.py
+++ b/tests/benchmarks/test_parse_gap_tuple.py
@@ -90,3 +90,24 @@ def test_parse_advertisement_data_tuple(benchmark: BenchmarkFixture) -> None:
 def test_parse_advertisement_data_tuple_uncached(benchmark: BenchmarkFixture) -> None:
     joined_advs = b"".join(advs)
     benchmark(lambda: _uncached_parse_advertisement_data(joined_advs))
+
+
+def test_parse_advertisement_data_tuple_bytes_cache_fallthrough(
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Tuple-cache misses must fall through to the bytes-keyed cache.
+
+    Simulates the steady-state case where bleak hands us a fresh tuple
+    identity per callback but the joined payload was already parsed (e.g.
+    same advertisement was seen via the bytes-form helper earlier).
+    """
+    from bluetooth_data_tools import parse_advertisement_data_bytes
+
+    joined = b"".join(advs)
+    parse_advertisement_data_bytes(joined)
+
+    def run() -> None:
+        parse_advertisement_data_tuple.cache_clear()
+        parse_advertisement_data_tuple(advs)
+
+    benchmark(run)


### PR DESCRIPTION
Adds a codspeed and benchmark case for `parse_advertisement_data_tuple` covering the miss path where the same payload already lives in the bytes cache; gives us a stable baseline before wiring the tuple miss through the bytes cache in a follow up.