### PR TITLE
chore(ruff): enforce imports at top level via PLC0415

### DIFF
--- a/bench/test_parse_gap_tuple.py
+++ b/bench/test_parse_gap_tuple.py
@@ -1,4 +1,7 @@
-from bluetooth_data_tools import parse_advertisement_data_tuple
+from bluetooth_data_tools import (
+    parse_advertisement_data_bytes,
+    parse_advertisement_data_tuple,
+)
 from bluetooth_data_tools.gap import _uncached_parse_advertisement_data
 
 #  cythonize -X language_level=3 -a -i  src/bluetooth_data_tools/gap.py
@@ -92,8 +95,6 @@ def test_parse_advertisement_data_tuple_uncached(benchmark):
 
 
 def test_parse_advertisement_data_tuple_bytes_cache_fallthrough(benchmark):
-    from bluetooth_data_tools import parse_advertisement_data_bytes
-
     joined = b"".join(advs)
     parse_advertisement_data_bytes(joined)
 

--- a/build_ext.py
+++ b/build_ext.py
@@ -63,7 +63,7 @@ def build(setup_kwargs: Any) -> None:
     if os.environ.get("SKIP_CYTHON", False):
         return
     try:
-        from Cython.Build import cythonize
+        from Cython.Build import cythonize  # noqa: PLC0415
 
         setup_kwargs.update(
             dict(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ extend-select = [
     "E",
     "F",
     "I", # isort
+    "PLC0415", # import-outside-toplevel
     "S", # security (bandit)
     "W",
     "UP", # pyupgrade

--- a/tests/benchmarks/test_parse_gap_tuple.py
+++ b/tests/benchmarks/test_parse_gap_tuple.py
@@ -1,7 +1,10 @@
 #  cythonize -X language_level=3 -a -i  src/bluetooth_data_tools/gap.py
 from pytest_codspeed import BenchmarkFixture
 
-from bluetooth_data_tools import parse_advertisement_data_tuple
+from bluetooth_data_tools import (
+    parse_advertisement_data_bytes,
+    parse_advertisement_data_tuple,
+)
 from bluetooth_data_tools.gap import _uncached_parse_advertisement_data
 
 advs = (
@@ -101,8 +104,6 @@ def test_parse_advertisement_data_tuple_bytes_cache_fallthrough(
     identity per callback but the joined payload was already parsed (e.g.
     same advertisement was seen via the bytes-form helper earlier).
     """
-    from bluetooth_data_tools import parse_advertisement_data_bytes
-
     joined = b"".join(advs)
     parse_advertisement_data_bytes(joined)
 

--- a/tests/test_gap.py
+++ b/tests/test_gap.py
@@ -1,4 +1,5 @@
 import base64
+import logging
 
 import pytest
 
@@ -103,8 +104,6 @@ def test_parse_advertisement_data_trailing_minimum_ad_struct(caplog):
     # Manufacturer-data struct (5 bytes) followed by a trailing minimum-AD
     # struct [length=1][type=0x09] (2 bytes). The loop must enter the trailing
     # struct rather than silently skip it; preceding data must still parse.
-    import logging
-
     data = [b"\x04\xff\x4c\x00\x10\x01\x09"]
 
     with caplog.at_level(logging.DEBUG, logger="bluetooth_data_tools.gap"):


### PR DESCRIPTION
Enables ruff PLC0415 so non top level imports are flagged going forward; moves the three existing function scoped imports in the test and bench suites up to the module imports so the rule passes cleanly.