### PR TITLE
test(bench): cover _uint128_bytes_as_uuid cached and uncached paths

### DIFF
--- a/bench/test_uint128_bytes_as_uuid.py
+++ b/bench/test_uint128_bytes_as_uuid.py
@@ -1,0 +1,15 @@
+from bluetooth_data_tools.gap import _uint128_bytes_as_uuid
+
+_UUID_BYTES = bytes(range(16))
+
+
+def test_uint128_bytes_as_uuid_cached(benchmark):
+    benchmark(lambda: _uint128_bytes_as_uuid(_UUID_BYTES))
+
+
+def test_uint128_bytes_as_uuid_uncached(benchmark):
+    def run():
+        _uint128_bytes_as_uuid.cache_clear()
+        _uint128_bytes_as_uuid(_UUID_BYTES)
+
+    benchmark(run)

--- a/tests/benchmarks/test_uint128_bytes_as_uuid.py
+++ b/tests/benchmarks/test_uint128_bytes_as_uuid.py
@@ -1,0 +1,17 @@
+from pytest_codspeed import BenchmarkFixture
+
+from bluetooth_data_tools.gap import _uint128_bytes_as_uuid
+
+_UUID_BYTES = bytes(range(16))
+
+
+def test_uint128_bytes_as_uuid_cached(benchmark: BenchmarkFixture) -> None:
+    benchmark(lambda: _uint128_bytes_as_uuid(_UUID_BYTES))
+
+
+def test_uint128_bytes_as_uuid_uncached(benchmark: BenchmarkFixture) -> None:
+    def run() -> None:
+        _uint128_bytes_as_uuid.cache_clear()
+        _uint128_bytes_as_uuid(_UUID_BYTES)
+
+    benchmark(run)


### PR DESCRIPTION
Adds a codspeed and pytest-benchmark case for _uint128_bytes_as_uuid covering both the cache hit and the cache miss path; gives us a stable baseline before rewriting the miss path to skip the int.from_bytes round trip in a follow up, matching the pattern used for the 16/32 bit variants in #270.