### PR TITLE
test(bench): cover human_readable_name

### DIFF
--- a/bench/test_human_readable_name.py
+++ b/bench/test_human_readable_name.py
@@ -1,0 +1,13 @@
+from bluetooth_data_tools import human_readable_name
+
+_NAME = "Living Room Sensor"
+_LOCAL_NAME = "RZSS"
+_ADDRESS = "AA:BB:CC:DD:EE:FF"
+
+
+def test_human_readable_name_with_name(benchmark):
+    benchmark(lambda: human_readable_name(_NAME, _LOCAL_NAME, _ADDRESS))
+
+
+def test_human_readable_name_local_only(benchmark):
+    benchmark(lambda: human_readable_name(None, _LOCAL_NAME, _ADDRESS))

--- a/tests/benchmarks/test_human_readable_name.py
+++ b/tests/benchmarks/test_human_readable_name.py
@@ -1,0 +1,17 @@
+from pytest_codspeed import BenchmarkFixture
+
+from bluetooth_data_tools import human_readable_name
+
+# Realistic scan shape: a known peripheral with a name plus a fresh
+# adv carrying only a local_name, both keyed by a hex BLE address.
+_NAME = "Living Room Sensor"
+_LOCAL_NAME = "RZSS"
+_ADDRESS = "AA:BB:CC:DD:EE:FF"
+
+
+def test_human_readable_name_with_name(benchmark: BenchmarkFixture) -> None:
+    benchmark(lambda: human_readable_name(_NAME, _LOCAL_NAME, _ADDRESS))
+
+
+def test_human_readable_name_local_only(benchmark: BenchmarkFixture) -> None:
+    benchmark(lambda: human_readable_name(None, _LOCAL_NAME, _ADDRESS))


### PR DESCRIPTION
Adds a codspeed and pytest-benchmark case for human_readable_name covering the common with name path and the local name only path; gives us a stable baseline before caching the result in a follow up.