### PR TITLE
test(bench): cover calculate_distance_meters close, far, zero branches

### DIFF
--- a/bench/test_calculate_distance_meters.py
+++ b/bench/test_calculate_distance_meters.py
@@ -1,0 +1,22 @@
+from bluetooth_data_tools import calculate_distance_meters
+
+_CLOSE_POWER = -4
+_CLOSE_RSSI = -3
+
+_FAR_POWER = -59
+_FAR_RSSI = -60
+
+_ZERO_POWER = 59
+_ZERO_RSSI = 0
+
+
+def test_calculate_distance_meters_close(benchmark):
+    benchmark(lambda: calculate_distance_meters(_CLOSE_POWER, _CLOSE_RSSI))
+
+
+def test_calculate_distance_meters_far(benchmark):
+    benchmark(lambda: calculate_distance_meters(_FAR_POWER, _FAR_RSSI))
+
+
+def test_calculate_distance_meters_zero(benchmark):
+    benchmark(lambda: calculate_distance_meters(_ZERO_POWER, _ZERO_RSSI))

--- a/tests/benchmarks/test_calculate_distance_meters.py
+++ b/tests/benchmarks/test_calculate_distance_meters.py
@@ -1,0 +1,27 @@
+from pytest_codspeed import BenchmarkFixture
+
+from bluetooth_data_tools import calculate_distance_meters
+
+# Close: ratio < 1, takes the pow(ratio, 10) branch.
+_CLOSE_POWER = -4
+_CLOSE_RSSI = -3
+
+# Far: ratio > 1, takes the 0.89976 * pow(ratio, 7.7095) + 0.111 branch.
+_FAR_POWER = -59
+_FAR_RSSI = -60
+
+# Zero rssi short circuits to None before any pow call.
+_ZERO_POWER = 59
+_ZERO_RSSI = 0
+
+
+def test_calculate_distance_meters_close(benchmark: BenchmarkFixture) -> None:
+    benchmark(lambda: calculate_distance_meters(_CLOSE_POWER, _CLOSE_RSSI))
+
+
+def test_calculate_distance_meters_far(benchmark: BenchmarkFixture) -> None:
+    benchmark(lambda: calculate_distance_meters(_FAR_POWER, _FAR_RSSI))
+
+
+def test_calculate_distance_meters_zero(benchmark: BenchmarkFixture) -> None:
+    benchmark(lambda: calculate_distance_meters(_ZERO_POWER, _ZERO_RSSI))


### PR DESCRIPTION
Adds a codspeed and pytest-benchmark case for calculate_distance_meters covering all three paths; the ratio < 1 branch, the ratio > 1 branch, and the zero short circuit. Gives us a stable baseline before swapping pow() for ** and dropping the * 1.0 idiom in a follow up.