### PR TITLE
ci: scope release env and OIDC permissions to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,19 +177,43 @@ jobs:
           run: poetry run pytest --no-cov -vvvvv --codspeed tests/benchmarks
           mode: instrumentation
 
+  # Dry run on PRs and non-main pushes. No environment, no publish
+  # permissions, no OIDC, so PR runs carry no release blast radius.
+  release-dry-run:
+    needs:
+      - test
+      - lint
+      - commitlint
+    if: github.ref_name != 'main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+      - name: Create local branch name
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: git switch -C "$BRANCH"
+      - name: Test release
+        uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
+        with:
+          no_operation_mode: true
+
+  # Real release, only on main. The release environment and write/OIDC
+  # permissions are scoped to this job so they never apply to PR runs.
   release:
     needs:
       - test
       - lint
       - commitlint
-
+    if: github.ref_name == 'main'
     runs-on: ubuntu-latest
-    # Only enter the protected 'release' environment when actually releasing
-    # from main; PR dry-runs would otherwise be blocked by the env's
-    # main-only branch policy.
-    environment: ${{ github.ref_name == 'main' && 'release' || '' }}
+    environment: release
     concurrency:
-      group: release-${{ github.head_ref || github.ref }}
+      group: release-${{ github.ref }}
       cancel-in-progress: false
     permissions:
       id-token: write
@@ -207,7 +231,6 @@ jobs:
       # PSR's URL-embedded auth at push time and re-attribute the push
       # to github-actions[bot].
       - name: Generate release App token
-        if: github.ref_name == 'main'
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -221,20 +244,14 @@ jobs:
           token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Create local branch name
-        run: git switch -C ${{ github.head_ref || github.ref_name }}
-
-      # Do a dry run of PSR
-      - name: Test release
-        uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
-        if: github.ref_name != 'main'
-        with:
-          no_operation_mode: true
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: git switch -C "$BRANCH"
 
       # On main branch: actual PSR + upload to PyPI & GitHub
       - name: Release
         uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
         id: release
-        if: github.ref_name == 'main'
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           force: ${{ inputs.force }}


### PR DESCRIPTION
## Summary

The release job held id-token: write, contents: write, and the release environment on every trigger including pull requests, even though it only published on main; this splits it into two jobs so PR runs no longer carry release credentials.

## Details

release-dry-run runs on PRs and non-main pushes with only contents: read, no environment and no OIDC, just the python-semantic-release dry run; release runs only on main and keeps the release environment plus write and OIDC permissions scoped to that job, so they never apply to untrusted PR code.

## Test plan

- [ ] workflow YAML parses clean
- [ ] dry-run job runs on this PR, publish job stays skipped
